### PR TITLE
chore: remove push event

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,8 +1,5 @@
 name: Generate and Deploy
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       url:


### PR DESCRIPTION
This action will not run when a push to the main branch. You need to manually dispatch workflow on the Actions page.